### PR TITLE
I think we went too far with UPPER CASE LETTERS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,5 @@
 /**
-* @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+* @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
 */
 module.exports = function (grunt) {
    grunt.initConfig({

--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ For issues, feature requests, or questions:
 
 ## Acknowledgments
 
-Developed under the PROJET R&I 2024 Composante 2 by the UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS and the Université Gaston-Berger. Special thanks to the Agence Universitaire de la Francophonie (AUF) for supporting this initiative.
+Developed under the *PROJET R&I 2024 Composante 2* by the Université TÉLUQ and the Université Gaston-Berger. Special thanks to the Agence Universitaire de la Francophonie (AUF) for supporting this initiative.

--- a/amd/src/fileupload.js
+++ b/amd/src/fileupload.js
@@ -1,5 +1,5 @@
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 define(['jquery', 'core/str'], function ($, str) {
     /**

--- a/amd/src/uteluqchatbot.js
+++ b/amd/src/uteluqchatbot.js
@@ -1,5 +1,5 @@
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 define(['jquery', 'core/str', 'core/ajax', 'core/notification'], function($, str, ajax, notification) {

--- a/block_uteluqchatbot.php
+++ b/block_uteluqchatbot.php
@@ -4,7 +4,7 @@
  * Chatbot block class for Moodle.
  *
  * @package    block_uteluqchatbot
- * @copyright  2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright  2025 Université TÉLUQ and the Université Gaston-Berger
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/admin_setting_test_button.php
+++ b/classes/admin_setting_test_button.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 

--- a/classes/external/save_prompt.php
+++ b/classes/external/save_prompt.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * External service for saving prompts
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 namespace block_uteluqchatbot\external;

--- a/classes/external/send_question.php
+++ b/classes/external/send_question.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * External service for sending questions to chatbot
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 namespace block_uteluqchatbot\external;

--- a/classes/external/upload_files.php
+++ b/classes/external/upload_files.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * External API for file upload and indexing
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 namespace block_uteluqchatbot\external;

--- a/classes/pdf_extract_api.php
+++ b/classes/pdf_extract_api.php
@@ -4,7 +4,7 @@
  *
  * @package    block_uteluqchatbot
  * @subpackage pdfextractapi
- * @copyright  2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright  2025 Université TÉLUQ and the Université Gaston-Berger
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -18,7 +18,7 @@
  * Privacy Subsystem implementation for block_uteluqchatbot.
  *
  * @package    block_uteluqchatbot
- * @copyright  2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright  2025 Université TÉLUQ and the Université Gaston-Berger
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/classes/weaviate_connector.php
+++ b/classes/weaviate_connector.php
@@ -4,7 +4,7 @@
  *
  * @package    block_uteluqchatbot
  * @subpackage weaviateconnector
- * @copyright  2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright  2025 Université TÉLUQ and the Université Gaston-Berger
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/access.php
+++ b/db/access.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 defined('MOODLE_INTERNAL') || die();

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <XMLDB PATH="blocks/uteluqchatbot/db" VERSION="20250129" COMMENT="XMLDB file for chatbot block">
     <!--
-      @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+      @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
     -->
     <TABLES>
         <TABLE NAME="block_uteluqchatbot_conversations" COMMENT="Stores chat conversations">

--- a/db/services.php
+++ b/db/services.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * External services for uteluqchatbot block
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 defined('MOODLE_INTERNAL') || die();

--- a/lang/ar/block_uteluqchatbot.php
+++ b/lang/ar/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'شات بوت';
 $string['uteluqchatbot:addinstance'] = 'أضف كتلة شات بوت جديدة';

--- a/lang/da/block_uteluqchatbot.php
+++ b/lang/da/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Tilføj en ny chatbot-blok';

--- a/lang/de/block_uteluqchatbot.php
+++ b/lang/de/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Füge einen neuen Chatbot-Block hinzu';

--- a/lang/en/block_uteluqchatbot.php
+++ b/lang/en/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Add a new chatbot block';

--- a/lang/es/block_uteluqchatbot.php
+++ b/lang/es/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Agregar un nuevo bloque de chatbot';

--- a/lang/fr/block_uteluqchatbot.php
+++ b/lang/fr/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Ajouter un nouveau bloc uteluqchatbot';

--- a/lang/ha/block_uteluqchatbot.php
+++ b/lang/ha/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 $string['pluginname'] = 'uteluqchatbot';

--- a/lang/hi/block_uteluqchatbot.php
+++ b/lang/hi/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'यूटेलूकचैटबॉट';
 $string['uteluqchatbot:addinstance'] = 'नया चैटबॉट ब्लॉक जोड़ें';

--- a/lang/it/block_uteluqchatbot.php
+++ b/lang/it/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Aggiungi un nuovo blocco chatbot';

--- a/lang/ja/block_uteluqchatbot.php
+++ b/lang/ja/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'チャットボット';
 $string['uteluqchatbot:addinstance'] = '新しいチャットボットブロックを追加';

--- a/lang/pl/block_uteluqchatbot.php
+++ b/lang/pl/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Dodaj nowy blok chatbot';

--- a/lang/pt/block_uteluqchatbot.php
+++ b/lang/pt/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Adicionar um novo bloco de chatbot';

--- a/lang/ru/block_uteluqchatbot.php
+++ b/lang/ru/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'Чатбот';
 $string['uteluqchatbot:addinstance'] = 'Добавить новый блок чатбота';

--- a/lang/sw/block_uteluqchatbot.php
+++ b/lang/sw/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = 'uteluqchatbot';
 $string['uteluqchatbot:addinstance'] = 'Ongeza kichaguzi kipya cha chatbot';

--- a/lang/zh_cn/block_uteluqchatbot.php
+++ b/lang/zh_cn/block_uteluqchatbot.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 $string['pluginname'] = '聊天机器人';
 $string['uteluqchatbot:addinstance'] = '添加新的聊天机器人块';

--- a/lib.php
+++ b/lib.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 /**

--- a/settings.php
+++ b/settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 require_once($CFG->dirroot . '/blocks/uteluqchatbot/classes/admin_setting_test_button.php');

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 /*!
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 

--- a/templates/load-course-modal.mustache
+++ b/templates/load-course-modal.mustache
@@ -17,7 +17,7 @@
     Example context (JSON):
     {}
 
-    @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+    @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
 }}
 <div class="block_uteluqchatbot">
     <div id="fileUploadModal" class="modal" style="display: none;">

--- a/templates/prompt_modal.mustache
+++ b/templates/prompt_modal.mustache
@@ -21,7 +21,7 @@
         "prompt_text": "You are a helpful teaching assistant for this course..."
     }
 
-    @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+    @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
 }}
 
 <div id="promptModal" class="block_uteluqchatbot modal" style="display: none;">

--- a/templates/uteluqchatbot.mustache
+++ b/templates/uteluqchatbot.mustache
@@ -24,7 +24,7 @@
         "isteacher": true
     }
 
-    @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+    @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
 }}
 
 <!DOCTYPE html>

--- a/test_api_keys.php
+++ b/test_api_keys.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 require_once('../../config.php');

--- a/theme.scss
+++ b/theme.scss
@@ -1,5 +1,5 @@
 /*!
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 .block-chatbot-container {

--- a/version.php
+++ b/version.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2025 UNIVERSITÉ TÉLUQ & UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS
+ * @copyright 2025 Université TÉLUQ and the Université Gaston-Berger
  */
 
 // This file is part of Moodle - https://moodle.org/


### PR DESCRIPTION

It seems that the usage is to write *Université Gaston Berger* and not *UNIVERSITÉ GASTON BERGER DE SAINT-LOUIS* although we do see the latter in some menus.

« L’Excellence au service du développement est le crédo de l’Université Gaston Berger de Saint-Louis. Depuis trente quatre ans (1990-2024) »

The wikipedia page refers to *Université Gaston Berger*: https://fr.wikipedia.org/wiki/Université_Gaston-Berger 


Regarding TÉLUQ, the proper usage is Université TÉLUQ: https://fr.wikipedia.org/wiki/Université_TÉLUQ